### PR TITLE
Set affinity mask via testbed file.

### DIFF
--- a/fabfile/tasks/helpers.py
+++ b/fabfile/tasks/helpers.py
@@ -830,8 +830,13 @@ def setup_coremask_node(*args):
 
         # supported coremask format: hex: (0x3f); list: (0,3-5), (0,1,2,3,4,5)
         # if specified as a list of cpus, -c flag must be provided to taskset
-        if ',' in coremask or '-' in coremask:
-            taskset_param = ' -c'
+        if re.compile('^0x[0-9a-fA-F]+$').match(coremask):
+            param = ''
+        elif re.compile('^[0-9\-\,]+$').match(coremask):
+            param = ' -c'
+        else:
+            print "Invalid coremask."
+            exit(1)
 
         # prepend taskset only if valid coremask was specified in testbed
         with settings(host_string=host_string):

--- a/fabfile/tasks/helpers.py
+++ b/fabfile/tasks/helpers.py
@@ -821,15 +821,16 @@ def setup_coremask_node(*args):
             try:
                 coremask = dpdk[env.host_string]['coremask']
             except KeyError:
-                coremask = default_coremask
+                return
         else:
             return
 
         if (coremask == ""):
-            coremask = default_coremask
+            return
 
+        # prepend taskset only if valid coremask was specified in testbed
         with settings(host_string=host_string):
-                sudo('sudo sed -i \'s/__COREMASK__/%s/\' %s' %(coremask, vrouter_file))
+            sudo('sed -i \'s/command=/command=taskset %s /\' %s' %(coremask, vrouter_file))
 
 @roles('openstack')
 @task

--- a/fabfile/tasks/helpers.py
+++ b/fabfile/tasks/helpers.py
@@ -830,7 +830,7 @@ def setup_coremask_node(*args):
 
         # supported coremask format: hex: (0x3f); list: (0,3-5), (0,1,2,3,4,5)
         # if specified as a list of cpus, -c flag must be provided to taskset
-        if ',' or '-' in coremask:
+        if ',' in coremask or '-' in coremask:
             taskset_param = ' -c'
 
         # prepend taskset only if valid coremask was specified in testbed

--- a/fabfile/tasks/provision.py
+++ b/fabfile/tasks/provision.py
@@ -1323,6 +1323,9 @@ def setup_only_vrouter_node(manage_nova_compute='yes', configure_nova='yes', *ar
         # Setup hugepages if necessary
         setup_hugepages_node(host_string)
 
+        # Setup affinity mask if necessary
+        setup_coremask_node(host_string)
+
         # Execute the script to provision compute node.
         with  settings(host_string=host_string):
             if detect_ostype() == 'ubuntu':
@@ -2049,4 +2052,3 @@ def setup_zones():
     """Setup availability zones."""
     setup_esx_zone()
 #end setup_zones
-

--- a/fabfile/testbeds/testbed_multibox_example.py
+++ b/fabfile/testbeds/testbed_multibox_example.py
@@ -442,8 +442,11 @@ env.orchestrator = 'openstack' #other values are 'vcenter' default:openstack
 # If some compute nodes should use DPDK vRouter version it has to be put in
 # env.dpdk dictionary. The format is:
 # env.dpdk = {
-#     host1: { 'huge_pages' : '50' },
-#     host2: { 'huge_pages' : '50' },
+#     host1: { 'huge_pages' : '50', 'coremask' : '0xf' },
+#     host2: { 'huge_pages' : '50', 'coremask' : '0,3-7' },
 # }
 # huge_pages - Specify what percentage of host memory should be reserved
 #              for access with huge pages
+# coremask - Specify CPU affinity mask to run vRouter with. Supported formats:
+#              hexadecimal, comma-sepparated list of CPUs, dash-separated range
+#              of CPUs.

--- a/fabfile/testbeds/testbed_singlebox_example.py
+++ b/fabfile/testbeds/testbed_singlebox_example.py
@@ -281,8 +281,11 @@ env.ostypes = {
 # If some compute nodes should use DPDK vRouter version it has to be put in
 # env.dpdk dictionary. The format is:
 # env.dpdk = {
-#     host1: { 'huge_pages' : '50' },
-#     host2: { 'huge_pages' : '50' },
+#     host1: { 'huge_pages' : '50', 'coremask' : '0xf' },
+#     host2: { 'huge_pages' : '50', 'coremask' : '0,3-7' },
 # }
 # huge_pages - Specify what percentage of host memory should be reserved
 #              for access with huge pages
+# coremask - Specify CPU affinity mask to run vRouter with. Supported formats:
+#              hexadecimal, comma-sepparated list of CPUs, dash-separated range
+#              of CPUs.


### PR DESCRIPTION
Implement setup_coremask_node() and call it during vRouter setup
to get affinity mask from the testbed file and put it into the
contrail-vrouter-dpdk.ini file.

Change-Id: Id68c7889b39889188088b35209682f46d9535ebd
